### PR TITLE
Add comics container (jodal/comics)

### DIFF
--- a/comics/Dockerfile
+++ b/comics/Dockerfile
@@ -1,0 +1,73 @@
+FROM python:3.12-slim-bookworm AS build
+SHELL ["sh", "-exc"]
+
+ARG COMICS_VERSION=main
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/app \
+    UV_PYTHON=/usr/local/bin/python \
+    UV_PYTHON_DOWNLOADS=never
+
+# Clone comics source
+RUN git clone --depth 1 --branch "${COMICS_VERSION}" https://github.com/jodal/comics.git /src
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache <<EOT
+cd /src
+uv sync \
+    --locked \
+    --no-dev \
+    --all-extras \
+    --no-install-project
+EOT
+
+# Install the app itself
+RUN --mount=type=cache,target=/root/.cache <<EOT
+cd /src
+uv sync \
+    --locked \
+    --no-dev \
+    --all-extras \
+    --no-editable
+EOT
+
+# Collect static files
+ENV DJANGO_STATIC_ROOT=/app/static
+RUN /app/bin/comics collectstatic --noinput && /app/bin/comics compress
+
+# ---
+
+FROM python:3.12-slim-bookworm AS runtime
+SHELL ["sh", "-exc"]
+
+ENV PATH=/app/bin:${PATH} \
+    DJANGO_STATIC_ROOT=/app/static \
+    DJANGO_MEDIA_ROOT=/media
+
+# Create non-root user
+RUN groupadd -g 1000 app && \
+    useradd -g 1000 -u 1000 -d /home/app -s /sbin/nologin app && \
+    mkdir -p /home/app /app /media && \
+    chown -R app:app /home/app /app /media
+
+# Copy app from build stage
+COPY --from=build --chown=app:app /app /app
+
+# Entrypoint script
+COPY --chown=app:app entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+STOPSIGNAL SIGINT
+USER 1000
+WORKDIR /app
+EXPOSE 8000
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["web"]

--- a/comics/entrypoint.sh
+++ b/comics/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+if [ "$1" = "shell" ]; then
+    exec comics shell ${*:2}
+fi
+
+if [ "$1" = "dbshell" ]; then
+    exec comics dbshell ${*:2}
+fi
+
+if [ "$1" = "web" ]; then
+    comics migrate
+    exec gunicorn \
+        --worker-tmp-dir=/dev/shm \
+        --log-file=- \
+        --bind=0.0.0.0:${PORT:-8000} \
+        comics.wsgi \
+        ${*:2}
+fi
+
+exec "$@"


### PR DESCRIPTION
Adds a container build for [jodal/comics](https://github.com/jodal/comics) — a web comics aggregator by Stein Magnus Jodal.

## What's included

- `comics/Dockerfile` — multi-stage build using uv, based on the [upstream draft PR #373](https://github.com/jodal/comics/pull/373)
- `comics/entrypoint.sh` — runs migrations then starts gunicorn on port 8000

## Still needed

The GitHub Actions workflow file (`comics.yml`) could not be pushed due to token scope. Add `.github/workflows/comics.yml`:

```yaml
name: comics

on:
  push:
    branches:
      - "main"

jobs:
  docker:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v6
      - name: Set up QEMU
        uses: docker/setup-qemu-action@v4
      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v4
      - name: Login to Docker Hub
        uses: docker/login-action@v4
        with:
          username: ${{ secrets.DOCKERHUB_USERNAME }}
          password: ${{ secrets.DOCKERHUB_TOKEN }}
      - name: Login to GitHub Container Registry
        uses: docker/login-action@v4
        with:
          registry: ghcr.io
          username: ${{ github.repository_owner }}
          password: ${{ secrets.LOCAL_GITHUB_TOKEN }}
      - name: Build and push
        uses: docker/build-push-action@v7
        with:
          context: comics/
          platforms: linux/amd64,linux/arm64
          push: true
          tags: |
            davralin/comics:latest
            ghcr.io/davralin/comics:latest
```

## Container details

- **Base:** `python:3.12-slim-bookworm`
- **Build:** uv (matches upstream tooling), clones from `main` branch
- **Extras:** pgsql, server, cache, api (all optional deps)
- **Runtime:** gunicorn on port 8000, non-root (UID 1000)
- **Env vars:** `DATABASE_URL`, `PORT` (default 8000), `DJANGO_STATIC_ROOT`, `DJANGO_MEDIA_ROOT`