### PR TITLE
Fix comics build: add libxml2/libxslt dev packages

### DIFF
--- a/comics/Dockerfile
+++ b/comics/Dockerfile
@@ -4,7 +4,12 @@ SHELL ["sh", "-exc"]
 ARG COMICS_VERSION=main
 
 # Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    build-essential \
+    libxml2-dev \
+    libxslt1-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv


### PR DESCRIPTION
The build failed because `lxml 6.0.0` needs to compile from source and requires `libxml2-dev`, `libxslt1-dev`, and `build-essential` in the build stage.

Failed run: https://github.com/davralin/containers/actions/runs/23716400977