### PR TITLE
Fix comics build: add zlib1g-dev for lxml linking

### DIFF
--- a/comics/Dockerfile
+++ b/comics/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libxml2-dev \
     libxslt1-dev \
+    zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv


### PR DESCRIPTION
lxml compiled successfully this time but the linker failed with `cannot find -lz`. Adding `zlib1g-dev` to the build deps.

Failed run: https://github.com/davralin/containers/actions/runs/23716502635