### PR TITLE
Fix comics build: use Python 3.13 (3.14 compat issue)

### DIFF
--- a/comics/Dockerfile
+++ b/comics/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim-bookworm AS build
+FROM python:3.13-slim-bookworm AS build
 SHELL ["sh", "-exc"]
 
 ARG COMICS_VERSION=main
@@ -50,7 +50,7 @@ RUN /app/bin/comics collectstatic --noinput && /app/bin/comics compress
 
 # ---
 
-FROM python:3.14-slim-bookworm AS runtime
+FROM python:3.13-slim-bookworm AS runtime
 SHELL ["sh", "-exc"]
 
 ENV PATH=/app/bin:${PATH} \


### PR DESCRIPTION
The build got past lxml but `httpcore` crashes on Python 3.14 with:

```
AttributeError: 'typing.Union' object has no attribute '__module__'
```

This is a known 3.14 compat issue with the `httpcore` version in the lockfile. Switching to 3.13 (still satisfies `>=3.12`).

Failed run: https://github.com/davralin/containers/actions/runs/23716588728