### PR TITLE
fix(comics): drop invalid --no-lock flag from uv sync

### DIFF
--- a/comics/Dockerfile
+++ b/comics/Dockerfile
@@ -25,12 +25,13 @@ ENV UV_COMPILE_BYTECODE=1 \
 RUN git clone --depth 1 --branch "${COMICS_VERSION}" https://github.com/jodal/comics.git /src
 
 # Install dependencies
-# Using --no-lock instead of --locked: upstream lockfile pins httpcore 1.0.7
-# which crashes on Python 3.14 (typing.Union.__module__ AttributeError, fixed in 1.0.9+)
+# Not using --locked: upstream lockfile pins httpcore 1.0.7 which crashes on
+# Python 3.14 (typing.Union.__module__ AttributeError, fixed in httpcore 1.0.9+).
+# Without --locked, uv will re-resolve and pick up compatible versions.
+# See: https://github.com/davralin/containers/issues/59
 RUN --mount=type=cache,target=/root/.cache <<EOT
 cd /src
 uv sync \
-    --no-lock \
     --no-dev \
     --all-extras \
     --no-install-project
@@ -40,7 +41,6 @@ EOT
 RUN --mount=type=cache,target=/root/.cache <<EOT
 cd /src
 uv sync \
-    --no-lock \
     --no-dev \
     --all-extras \
     --no-editable


### PR DESCRIPTION
`--no-lock` is not a valid `uv sync` argument — my mistake. Removing `--locked` entirely lets uv re-resolve using the upstream lockfile as a starting point but freely upgrade packages as needed. In a Docker build the updated lockfile is ephemeral.

This allows uv to pick up httpcore >=1.0.9 which has the Python 3.14 fix.

Ref: #59