### PR TITLE
fix(comics): delete upstream lockfile to resolve httpcore Python 3.14 crash

### DIFF
--- a/comics/Dockerfile
+++ b/comics/Dockerfile
@@ -25,10 +25,12 @@ ENV UV_COMPILE_BYTECODE=1 \
 RUN git clone --depth 1 --branch "${COMICS_VERSION}" https://github.com/jodal/comics.git /src
 
 # Install dependencies
-# Not using --locked: upstream lockfile pins httpcore 1.0.7 which crashes on
-# Python 3.14 (typing.Union.__module__ AttributeError, fixed in httpcore 1.0.9+).
-# Without --locked, uv will re-resolve and pick up compatible versions.
+# Upstream lockfile pins httpcore 1.0.7 which crashes on Python 3.14
+# (typing.Union.__module__ AttributeError, fixed in httpcore 1.0.8+).
+# Delete the lockfile so uv sync re-resolves all dependencies.
 # See: https://github.com/davralin/containers/issues/59
+RUN rm -f /src/uv.lock
+
 RUN --mount=type=cache,target=/root/.cache <<EOT
 cd /src
 uv sync \


### PR DESCRIPTION
The previous fix (dropping `--locked`) was insufficient — `uv sync` still respects the lockfile even without the flag, so it kept resolving httpcore 1.0.7 which crashes on Python 3.14.

This adds `rm -f /src/uv.lock` before the sync step, forcing uv to re-resolve dependencies from scratch and pick up httpcore >=1.0.8 (which fixes the `typing.Union.__module__` AttributeError).

Ref: #59