### PR TITLE
chore: auto-merge digest updates for container base images

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,8 @@
     {
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["digest"],
+      "automerge": true,
+      "automergeType": "branch",
       "commitMessagePrefix": "chore(container): ",
       "commitMessageTopic": "{{depName}}",
       "commitMessageExtra": "( {{currentDigestShort}} → {{newDigestShort}} )"


### PR DESCRIPTION
Adds `automerge: true` with `automergeType: branch` for digest updates on docker datasources. Digest-only bumps (like PR #68) will now merge automatically without manual intervention.