### PR TITLE
fix(openclaw): add openssh-client for git-sync push to Forgejo

### DIFF
--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -15,6 +15,7 @@ RUN \
   /usr/bin/apt-get -y install --no-install-recommends \
     jq \
     less \
+    openssh-client \
     python3 \
     vim-tiny && \
   /usr/bin/rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
The workspace git-sync script uses SSH to push to Forgejo (`git@forgejo-internal:...`), but `openssh-client` was never included in the container image. This adds it to the apt install list.

Without this, `git push` fails with `ssh: not found`.